### PR TITLE
Set NIST-800-53 references as rule annotations

### DIFF
--- a/cmd/profileparser/main.go
+++ b/cmd/profileparser/main.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/JAORMX/compliance-profile-operator/pkg/profileparser"
 
@@ -19,9 +17,7 @@ import (
 	"github.com/subchen/go-xmldom"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -34,11 +30,6 @@ import (
 )
 
 var log = logf.Log.WithName("profileparser")
-
-const (
-	machineConfigFixType = "urn:xccdf:fix:script:ignition"
-	kubernetesFixType    = "urn:xccdf:fix:script:kubernetes"
-)
 
 // XMLDocument is a wrapper that keeps the interface XML-parser-agnostic
 type XMLDocument struct {
@@ -220,112 +211,6 @@ func parseProfilesAndDo(contentDom *xmldom.Document, pcfg *profileparser.ParserC
 	return nil
 }
 
-func parseRulesAndDo(contentDom *xmldom.Document, pcfg *profileparser.ParserConfig, action func(p *cmpv1alpha1.Rule) error) error {
-	ruleObjs := contentDom.Root.Query("//Rule")
-	for _, ruleObj := range ruleObjs {
-		id := ruleObj.GetAttributeValue("id")
-		if id == "" {
-			return profileparser.LogAndReturnError("no id in rule")
-		}
-		title := ruleObj.FindOneByName("title")
-		if title == nil {
-			return profileparser.LogAndReturnError("no title in rule")
-		}
-		log.Info("Found rule", "id", id)
-
-		description := ruleObj.FindOneByName("description")
-		rationale := ruleObj.FindOneByName("rationale")
-		warning := ruleObj.FindOneByName("warning")
-		severity := ruleObj.FindOneByName("severity")
-
-		fixes := []cmpv1alpha1.FixDefinition{}
-		foundPlatformMap := make(map[string]bool)
-		fixNodeObjs := ruleObj.FindByName("fix")
-		for _, fixNodeObj := range fixNodeObjs {
-			if !isRelevantFix(fixNodeObj) {
-				continue
-			}
-			platform := fixNodeObj.GetAttributeValue("platform")
-			if foundPlatformMap[platform] {
-				// We already have a remediation for this platform
-				continue
-			}
-
-			rawFixReader := strings.NewReader(fixNodeObj.Text)
-			fixKubeObj, err := readObjFromYAML(rawFixReader)
-			if err != nil {
-				log.Info("Couldn't parse Kubernetes object from fix")
-				continue
-			}
-
-			disruption := fixNodeObj.GetAttributeValue("disruption")
-
-			newFix := cmpv1alpha1.FixDefinition{
-				Disruption: disruption,
-				Platform:   platform,
-				FixObject:  fixKubeObj,
-			}
-			fixes = append(fixes, newFix)
-			foundPlatformMap[platform] = true
-		}
-
-		p := cmpv1alpha1.Rule{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Rule",
-				APIVersion: cmpv1alpha1.SchemeGroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      xccdf.GetRuleNameFromID(id),
-				Namespace: pcfg.ProfileBundleKey.Namespace,
-			},
-			ID:             id,
-			Title:          title.Text,
-			AvailableFixes: nil,
-		}
-		if description != nil {
-			p.Description = description.Text
-		}
-		if rationale != nil {
-			p.Rationale = rationale.Text
-		}
-		if warning != nil {
-			p.Warning = warning.Text
-		}
-		if severity != nil {
-			p.Severity = severity.Text
-		}
-		if len(fixes) > 0 {
-			p.AvailableFixes = fixes
-		}
-		err := action(&p)
-		if err != nil {
-			log.Error(err, "couldn't execute action for rule")
-			// We continue even if there's an error.
-		}
-	}
-
-	return nil
-}
-
-// Reads a YAML file and returns an unstructured object from it. This object
-// can be taken into use by the dynamic client
-func readObjFromYAML(r io.Reader) (*unstructured.Unstructured, error) {
-	obj := &unstructured.Unstructured{}
-	dec := k8syaml.NewYAMLToJSONDecoder(r)
-	err := dec.Decode(obj)
-	return obj, err
-}
-
-func isRelevantFix(fix *xmldom.Node) bool {
-	if fix.GetAttributeValue("system") == machineConfigFixType {
-		return true
-	}
-	if fix.GetAttributeValue("system") == kubernetesFixType {
-		return true
-	}
-	return false
-}
-
 func getPrefixedName(pbName, objName string) string {
 	return pbName + "-" + objName
 }
@@ -409,7 +294,7 @@ func main() {
 		return
 	}
 
-	err = parseRulesAndDo(contentDom, pcfg, func(r *cmpv1alpha1.Rule) error {
+	err = profileparser.ParseRulesAndDo(contentDom, pcfg, func(r *cmpv1alpha1.Rule) error {
 		ruleName := r.Name
 		// overwrite name
 		r.SetName(getPrefixedName(pb.Name, ruleName))

--- a/pkg/profileparser/profileparser.go
+++ b/pkg/profileparser/profileparser.go
@@ -5,11 +5,20 @@ import (
 	cmpv1alpha1 "github.com/JAORMX/compliance-profile-operator/pkg/apis/compliance/v1alpha1"
 	"github.com/JAORMX/compliance-profile-operator/pkg/xccdf"
 	"github.com/subchen/go-xmldom"
+	"io"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+)
+
+const (
+	machineConfigFixType = "urn:xccdf:fix:script:ignition"
+	kubernetesFixType    = "urn:xccdf:fix:script:kubernetes"
 )
 
 var log = logf.Log.WithName("profileparser")
@@ -122,4 +131,110 @@ func parseVarValues(varNode *xmldom.Node, v *cmpv1alpha1.Variable) error {
 	}
 
 	return nil
+}
+
+func ParseRulesAndDo(contentDom *xmldom.Document, pcfg *ParserConfig, action func(p *cmpv1alpha1.Rule) error) error {
+	ruleObjs := contentDom.Root.Query("//Rule")
+	for _, ruleObj := range ruleObjs {
+		id := ruleObj.GetAttributeValue("id")
+		if id == "" {
+			return LogAndReturnError("no id in rule")
+		}
+		title := ruleObj.FindOneByName("title")
+		if title == nil {
+			return LogAndReturnError("no title in rule")
+		}
+		log.Info("Found rule", "id", id)
+
+		description := ruleObj.FindOneByName("description")
+		rationale := ruleObj.FindOneByName("rationale")
+		warning := ruleObj.FindOneByName("warning")
+		severity := ruleObj.FindOneByName("severity")
+
+		fixes := []cmpv1alpha1.FixDefinition{}
+		foundPlatformMap := make(map[string]bool)
+		fixNodeObjs := ruleObj.FindByName("fix")
+		for _, fixNodeObj := range fixNodeObjs {
+			if !isRelevantFix(fixNodeObj) {
+				continue
+			}
+			platform := fixNodeObj.GetAttributeValue("platform")
+			if foundPlatformMap[platform] {
+				// We already have a remediation for this platform
+				continue
+			}
+
+			rawFixReader := strings.NewReader(fixNodeObj.Text)
+			fixKubeObj, err := readObjFromYAML(rawFixReader)
+			if err != nil {
+				log.Info("Couldn't parse Kubernetes object from fix")
+				continue
+			}
+
+			disruption := fixNodeObj.GetAttributeValue("disruption")
+
+			newFix := cmpv1alpha1.FixDefinition{
+				Disruption: disruption,
+				Platform:   platform,
+				FixObject:  fixKubeObj,
+			}
+			fixes = append(fixes, newFix)
+			foundPlatformMap[platform] = true
+		}
+
+		p := cmpv1alpha1.Rule{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Rule",
+				APIVersion: cmpv1alpha1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      xccdf.GetRuleNameFromID(id),
+				Namespace: pcfg.ProfileBundleKey.Namespace,
+			},
+			ID:             id,
+			Title:          title.Text,
+			AvailableFixes: nil,
+		}
+		if description != nil {
+			p.Description = description.Text
+		}
+		if rationale != nil {
+			p.Rationale = rationale.Text
+		}
+		if warning != nil {
+			p.Warning = warning.Text
+		}
+		if severity != nil {
+			p.Severity = severity.Text
+		}
+		if len(fixes) > 0 {
+			p.AvailableFixes = fixes
+		}
+		err := action(&p)
+		if err != nil {
+			log.Error(err, "couldn't execute action for rule")
+			// We continue even if there's an error.
+		}
+	}
+
+	return nil
+}
+
+// Reads a YAML file and returns an unstructured object from it. This object
+// can be taken into use by the dynamic client
+func readObjFromYAML(r io.Reader) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	dec := k8syaml.NewYAMLToJSONDecoder(r)
+	err := dec.Decode(obj)
+	return obj, err
+}
+
+func isRelevantFix(fix *xmldom.Node) bool {
+	if fix.GetAttributeValue("system") == machineConfigFixType {
+		return true
+	}
+	if fix.GetAttributeValue("system") == kubernetesFixType {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
When creating rules, checks for reference elements whose href attribute 
matches the NIST-800-53 location. These references are then put to a label
called control.compliance.openshift.io/nist-800-53 separated by a 
semicolon.